### PR TITLE
Backport overlay security fix

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <uses-permission android:name="android.permission.KILL_UID" />
     <uses-permission android:name="android.permission.MANAGE_APP_OPS_RESTRICTIONS" />
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.HIDE_NON_SYSTEM_OVERLAY_WINDOWS" />
 
     <uses-permission android:name="com.google.android.permission.INSTALL_WEARABLE_PACKAGES" />
 

--- a/src/com/android/packageinstaller/permission/ui/OverlayTouchActivity.java
+++ b/src/com/android/packageinstaller/permission/ui/OverlayTouchActivity.java
@@ -15,33 +15,14 @@
  */
 package com.android.packageinstaller.permission.ui;
 
+import static android.view.WindowManager.LayoutParams.PRIVATE_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS;
+
 import android.app.Activity;
-import android.app.AppOpsManager;
-import android.os.Binder;
-import android.os.IBinder;
+import android.os.Bundle;
 
 public class OverlayTouchActivity extends Activity {
-    private final IBinder mToken = new Binder();
-
-    @Override
-    protected void onResume() {
-        super.onResume();
-        setOverlayAllowed(false);
-    }
-
-    @Override
-    protected void onPause() {
-        super.onPause();
-        setOverlayAllowed(true);
-    }
-
-    private void setOverlayAllowed(boolean allowed) {
-        AppOpsManager appOpsManager = getSystemService(AppOpsManager.class);
-        if (appOpsManager != null) {
-            appOpsManager.setUserRestriction(AppOpsManager.OP_SYSTEM_ALERT_WINDOW,
-                    !allowed, mToken);
-            appOpsManager.setUserRestriction(AppOpsManager.OP_TOAST_WINDOW,
-                    !allowed, mToken);
-        }
+    protected void onCreate(Bundle savedInstanceState) {
+        getWindow().addPrivateFlags(PRIVATE_FLAG_HIDE_NON_SYSTEM_OVERLAY_WINDOWS);
+        super.onCreate(savedInstanceState);
     }
 }


### PR DESCRIPTION
Replacing app opps fix with the flag that is used
elsewhere.

Bug: 37442941
Test: Verified that toast and system overlay still goes
away on permission and a11y service capability screens.

Merged-In: I27d357b2aa61193380b7ef1dcc88bbac9553644e

Change-Id: Ib7a7251109ed0f125db2bd49f5fc0baa67207b5d
(cherry picked from commit bb1948fe1a3fa2ca93f508af2e97f5ec21e71ade)